### PR TITLE
Adds compatibility support for MGSFPSUnlock

### DIFF
--- a/MGS3CrouchWalk/dllmain.cpp
+++ b/MGS3CrouchWalk/dllmain.cpp
@@ -1,4 +1,6 @@
 #include <shlwapi.h>
+#include <iostream>
+#include <filesystem>
 #include "Memory.h"
 #include "MinHook.h"
 #include "ini.h"
@@ -16,6 +18,7 @@ bool CrouchMoving = false;
 bool CrouchMovingSlow = false;
 bool IgnoreButtonHold = false;
 bool HijackSequence = false;
+mINI::INIStructure FPSUnlockConfig;
 
 // config values
 float CamoIndexModifier = 1.0f;
@@ -209,6 +212,18 @@ void ReadConfig()
     CrouchStalkSpeed = std::stof(Config["Settings"]["CrouchStalkSpeed"]);
 }
 
+void ReadFPSUnlockConfig()
+{   
+    if (!std::filesystem::exists("MGSFPSUnlock.asi")) {
+        return;
+    }
+    mINI::INIFile file("MGSFPSUnlock.ini");
+    file.read(FPSUnlockConfig);
+    double TargetFrameRate = std::stof(FPSUnlockConfig["Settings"]["TargetFrameRate"]);
+    CrouchWalkSpeed = CrouchWalkSpeed * (60.0/TargetFrameRate);
+    CrouchStalkSpeed = CrouchStalkSpeed * (60.0/TargetFrameRate);
+}
+
 DWORD WINAPI MainThread(LPVOID lpParam)
 {
     WCHAR exePath[_MAX_PATH] = { 0 };
@@ -220,6 +235,7 @@ DWORD WINAPI MainThread(LPVOID lpParam)
 
     Sleep(3000); // delay, just in case
     ReadConfig();
+    ReadFPSUnlockConfig();
     InstallHooks();
 
     return true;

--- a/MGS3CrouchWalk/dllmain.cpp
+++ b/MGS3CrouchWalk/dllmain.cpp
@@ -1,6 +1,4 @@
 #include <shlwapi.h>
-#include <iostream>
-#include <filesystem>
 #include "Memory.h"
 #include "MinHook.h"
 #include "ini.h"
@@ -18,7 +16,6 @@ bool CrouchMoving = false;
 bool CrouchMovingSlow = false;
 bool IgnoreButtonHold = false;
 bool HijackSequence = false;
-mINI::INIStructure FPSUnlockConfig;
 double* actorWaitValue = nullptr;
 
 // config values
@@ -192,7 +189,6 @@ void InstallHooks()
     uintptr_t getBtnHoldStateOffset     = (uintptr_t)Memory::PatternScan(GameModule, "44 0F B7 8A 8E 00 00 00 4C 8B C2 66 45 85 C9 78");
     uintptr_t motionPlaySeqOffset       = (uintptr_t)Memory::PatternScan(GameModule, "4D 63 D8 48 85 C9 74 6B  48 63 C2 48 8D 14 40 48");
     uint8_t* disableCrouchProneOffset   = Memory::PatternScan(GameModule, "00 00 7E 19 83 4F 68 10");
-
     uint8_t* actorWaitValueOffset       = Memory::PatternScan(GameModule, "83 3D ?? ?? ?? ?? 00 ?? ?? F2 0F 10 0D");
     if(actorWaitValueOffset != nullptr)
         actorWaitValue = reinterpret_cast<double*>(GetRelativeOffset(actorWaitValueOffset+13));
@@ -228,18 +224,6 @@ void ReadConfig()
     CrouchStalkSpeed = std::stof(Config["Settings"]["CrouchStalkSpeed"]);
 }
 
-void ReadFPSUnlockConfig() //Fallback in case we can't detect actorWaitValue via PatternScan()
-{
-    if (!std::filesystem::exists("MGSFPSUnlock.asi")) {
-        return;
-    }
-    mINI::INIFile file("MGSFPSUnlock.ini");
-    file.read(FPSUnlockConfig);
-    double TargetFrameRate = std::stof(FPSUnlockConfig["Settings"]["TargetFrameRate"]);
-    CrouchWalkSpeed = CrouchWalkSpeed * (60.0/TargetFrameRate);
-    CrouchStalkSpeed = CrouchStalkSpeed * (60.0/TargetFrameRate);
-}
-
 DWORD WINAPI MainThread(LPVOID lpParam)
 {
     WCHAR exePath[_MAX_PATH] = { 0 };
@@ -252,9 +236,6 @@ DWORD WINAPI MainThread(LPVOID lpParam)
     Sleep(3000); // delay, just in case
     ReadConfig();
     InstallHooks();
-    if (actorWaitValue == nullptr) {
-        ReadFPSUnlockConfig();
-    }
 
     return true;
 }

--- a/MGS3CrouchWalk/dllmain.cpp
+++ b/MGS3CrouchWalk/dllmain.cpp
@@ -148,10 +148,12 @@ int* __fastcall ActionSquatStillHook(int64_t work, MovementWork* plWork, int64_t
 
         if (mCtrlGlobal != NULL)
         {
-            if (actorWaitValue != nullptr) {
+            if (actorWaitValue != nullptr) 
+            {
                 mCtrlGlobal->mtcmControl->motionTimeBase = (CrouchMovingSlow ? CrouchStalkSpeed : CrouchWalkSpeed) * (*actorWaitValue / (1.0 / 60));
             }
-            else {
+            else 
+            {
                 mCtrlGlobal->mtcmControl->motionTimeBase = CrouchMovingSlow ? CrouchStalkSpeed : CrouchWalkSpeed;
             }
 
@@ -191,7 +193,9 @@ void InstallHooks()
     uint8_t* disableCrouchProneOffset   = Memory::PatternScan(GameModule, "00 00 7E 19 83 4F 68 10");
     uint8_t* actorWaitValueOffset       = Memory::PatternScan(GameModule, "83 3D ?? ?? ?? ?? 00 ?? ?? F2 0F 10 0D");
     if(actorWaitValueOffset != nullptr)
-        actorWaitValue = reinterpret_cast<double*>(GetRelativeOffset(actorWaitValueOffset+13));
+    {
+        actorWaitValue = reinterpret_cast<double*>(GetRelativeOffset(actorWaitValueOffset + 13));
+    }
 
 
     ActSquatStillOffset     = (uintptr_t)Memory::PatternScan(GameModule, "4C 8B DC 55 57 41 56 49 8D 6B A1 48 81 EC 00 01");

--- a/MGS3CrouchWalk/dllmain.cpp
+++ b/MGS3CrouchWalk/dllmain.cpp
@@ -19,6 +19,7 @@ bool CrouchMovingSlow = false;
 bool IgnoreButtonHold = false;
 bool HijackSequence = false;
 mINI::INIStructure FPSUnlockConfig;
+double* actorWaitValue = nullptr;
 
 // config values
 float CamoIndexModifier = 1.0f;
@@ -150,7 +151,12 @@ int* __fastcall ActionSquatStillHook(int64_t work, MovementWork* plWork, int64_t
 
         if (mCtrlGlobal != NULL)
         {
-            mCtrlGlobal->mtcmControl->motionTimeBase = CrouchMovingSlow ? CrouchStalkSpeed : CrouchWalkSpeed;
+            if (actorWaitValue != nullptr) {
+                mCtrlGlobal->mtcmControl->motionTimeBase = (CrouchMovingSlow ? CrouchStalkSpeed : CrouchWalkSpeed) * (*actorWaitValue / (1.0 / 60));
+            }
+            else {
+                mCtrlGlobal->mtcmControl->motionTimeBase = CrouchMovingSlow ? CrouchStalkSpeed : CrouchWalkSpeed;
+            }
 
             auto mtsqCntrl = *((uintptr_t*)mCtrlGlobal + 15);
 
@@ -171,6 +177,11 @@ int* __fastcall ActionSquatStillHook(int64_t work, MovementWork* plWork, int64_t
     return result;
 }
 
+uintptr_t GetRelativeOffset(uint8_t* addr)
+{
+    return reinterpret_cast<uintptr_t>(addr) + 4 + *reinterpret_cast<int32_t*>(addr);
+}
+
 void InstallHooks()
 {
     int status = MH_Initialize();
@@ -181,6 +192,11 @@ void InstallHooks()
     uintptr_t getBtnHoldStateOffset     = (uintptr_t)Memory::PatternScan(GameModule, "44 0F B7 8A 8E 00 00 00 4C 8B C2 66 45 85 C9 78");
     uintptr_t motionPlaySeqOffset       = (uintptr_t)Memory::PatternScan(GameModule, "4D 63 D8 48 85 C9 74 6B  48 63 C2 48 8D 14 40 48");
     uint8_t* disableCrouchProneOffset   = Memory::PatternScan(GameModule, "00 00 7E 19 83 4F 68 10");
+
+    uint8_t* actorWaitValueOffset       = Memory::PatternScan(GameModule, "83 3D ?? ?? ?? ?? 00 ?? ?? F2 0F 10 0D");
+    if(actorWaitValueOffset != nullptr)
+        actorWaitValue = reinterpret_cast<double*>(GetRelativeOffset(actorWaitValueOffset+13));
+
 
     ActSquatStillOffset     = (uintptr_t)Memory::PatternScan(GameModule, "4C 8B DC 55 57 41 56 49 8D 6B A1 48 81 EC 00 01");
     InitializeCamoIndex     = (InitializeCamoIndexDelegate*)Memory::PatternScan(GameModule, "85 D2 75 33 0F 57 C0 48 63 C2 48 C1 E0 07 48 8D");
@@ -212,8 +228,8 @@ void ReadConfig()
     CrouchStalkSpeed = std::stof(Config["Settings"]["CrouchStalkSpeed"]);
 }
 
-void ReadFPSUnlockConfig()
-{   
+void ReadFPSUnlockConfig() //Fallback in case we can't detect actorWaitValue via PatternScan()
+{
     if (!std::filesystem::exists("MGSFPSUnlock.asi")) {
         return;
     }
@@ -235,8 +251,10 @@ DWORD WINAPI MainThread(LPVOID lpParam)
 
     Sleep(3000); // delay, just in case
     ReadConfig();
-    ReadFPSUnlockConfig();
     InstallHooks();
+    if (actorWaitValue == nullptr) {
+        ReadFPSUnlockConfig();
+    }
 
     return true;
 }


### PR DESCRIPTION
crouchwalking speed is presently tied to framerate, and the speed multipliers you set in the config file get doubled/tripled/ect when using mgsfpsunlock. 

this makes the speed multipliers always consistent by parsing MGSFPSUnlock's ini for the target fps & adjusting accordingly.